### PR TITLE
Fix min_caml_create_array

### DIFF
--- a/interp.ml
+++ b/interp.ml
@@ -159,7 +159,7 @@ and interp' (prog : prog_with_label) (exp' : exp) (reg : register) (mem : memory
     (* id_t + id_or_imm * x の番地から load *)
     let dest = match id_t with
       | "min_caml_hp" -> !heap_pointer
-      | _ -> reg.(int_of_id_t id_t)
+      | _ -> int_of_id_t id_t
     in
     let offset = (match id_or_imm with
        | V id_t -> reg.(int_of_id_t id_t)
@@ -176,7 +176,7 @@ and interp' (prog : prog_with_label) (exp' : exp) (reg : register) (mem : memory
     in
     let dest = match id_t1 with
         "min_caml_hp" -> !heap_pointer
-      | _ -> reg.(int_of_id_t id_t2)
+      | _ -> int_of_id_t id_t2
     in
     let offset = (match id_or_imm with
         | V "min_caml_hp" -> !heap_pointer


### PR DESCRIPTION
```bash
$ ./min-caml -interp test/array
ree variable print_int assumed as external
iteration 1000
iteration 999
2

$ ./test/array
sp = 0xbff0aae0, hp = 0x200000
2

$ ./min-caml -interp test/non-tail-if
free variable print_int assumed as external
iteration 1000
iteration 999
directly applying f.13
eliminating closure(s) f.13
80238

$ ./test/non-tail-if2
sp = 0xbff0aad0, hp = 0x200000
80238
```                                                                                                                            